### PR TITLE
Log expansions of macros

### DIFF
--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -274,7 +274,10 @@ sub readXToken {
             . "Control sequence: " . Stringify($token) . ". "
             . "(object ID: "  . (Scalar::Util::refaddr $token) . "). "
             . "Current expansion depth: " . $newExpansionDepth . ". "
-            . "(If it was read from file, it ended at line " . $self->getMouth->{lineno} . ", col " . $self->getMouth->{colno} . ").\n"
+            . "(If this was a literal control sequence in a file rather than from an expansion, "
+            . "it appeared in " . $self->getMouth->{source} . " "
+            . "from line " . $self->getMouth->{lastlineno} . ", col " . $self->getMouth->{lastcolno} . " "
+            . "to line " . $self->getMouth->{lineno} . ", col " . $self->getMouth->{colno} . ").\n";
         }
         local $LaTeXML::CURRENT_TOKEN = $token;
         my $invoked   = $defn->invoke($self) || [];

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -241,7 +241,7 @@ sub readToken {
     # instead of the original TeX file.
     if ($STATE->lookupValue("IN_MATH") && $STATE->lookupValue("EXPANSION_DEPTH")) {
       my $tokenString = $token->toString();
-      print "Argument token: \"$tokenString\" "
+      print "Argument token (from pushback): \"$tokenString\" "
         . "(object ID: "  . (Scalar::Util::refaddr $token) . "). "
         . "From pushback (i.e., likely from expansion).\n"
     }
@@ -259,7 +259,7 @@ sub readToken {
     # delimiters between those arguments. This block of code should be triggered when an argument
     # or delimiter is read from the mouth (i.e., the original source file) rather than the pushback
     # (i.e., the output of prior expansions).
-    print "Argument token: \"$tokenString\" "
+    print "Argument token (from file): \"$tokenString\" "
       . "(object ID: "  . (Scalar::Util::refaddr $token) . "). "
       . "(source file $sourceName, "
       . "from line " . $$self{mouth}->{lastlineno} . " col " . $$self{mouth}->{lastcolno} . " "

--- a/lib/LaTeXML/Core/Gullet.pm
+++ b/lib/LaTeXML/Core/Gullet.pm
@@ -274,6 +274,11 @@ sub readXToken {
         else {
           Fatal('misdefined', $r, undef, "Expected a Token, got " . Stringify($_)); } }
       next unless @expansion;
+      
+      print "Definition: " . Stringify($defn) . "\n";
+      my $expanded_text = join('', map { $_->toString() } @expansion);
+      print "Expansion: " . $expanded_text . "\n";
+      
       if ($$LaTeXML::Core::Token::SMUGGLE_THE_COMMANDS{ $$defn{cs}[0] }) {
         # magic THE_TOKS handling, add to pushback with a single-use noexpand flag only valid
         #    at the exact time

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -322,7 +322,7 @@ sub readToken {
     my $token = (defined $cc ? $DISPATCH[$cc] : undef);
     $token = &$token($self, $ch) if ref $token eq 'CODE';
 
-    if (defined $token) {
+    if ($STATE->lookupValue("EXPANSION_DEPTH") && defined $token) {
       my $tokenString = $token->toString();
       # Switch this to 'source' for the full path.
       my $sourceName = $$self{shortsource} ? $$self{shortsource} : "unknown";

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -326,7 +326,7 @@ sub readToken {
       my $tokenString = $token->toString();
       # Switch this to 'source' for the full path.
       my $sourceName = $$self{shortsource} ? $$self{shortsource} : "unknown";
-      print "Token: \"$tokenString\" (source file $sourceName, from line $startLine col $startCol to line $$self{lineno} col $$self{colno})\n";
+      print "Argument token: \"$tokenString\" (source file $sourceName, from line $startLine col $startCol to line $$self{lineno} col $$self{colno})\n";
     }
     return $token if defined $token;    # Else, repeat till we get something or run out.
 

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -81,6 +81,8 @@ sub initialize {
   my ($self) = @_;
   $$self{lineno} = 0;
   $$self{colno}  = 0;
+  $$self{lastlineno} = 0;
+  $$self{lastcolno} = 0;
   $$self{chars}  = [];
   $$self{nchars} = 0;
   if ($$self{notes}) {
@@ -100,6 +102,8 @@ sub finish {
   $$self{buffer} = [];
   $$self{lineno} = 0;
   $$self{colno}  = 0;
+  $$self{lastlineno} = 0;
+  $$self{lastcolno} = 0;
   $$self{chars}  = [];
   $$self{nchars} = 0;
   if ($$self{fordefinitions}) {
@@ -270,12 +274,10 @@ my @DISPATCH = (    # [CONSTANT]
 # LaTeXML::Core::Gullet intercepts them and passes them on at appropriate times.
 sub readToken {
   my ($self) = @_;
-  my $startLine;
-  my $startCol;
   while (1) {    # Iterate till we find a token, or run out. (use return)
                  # ===== Get next line, if we need to.
-    $startCol = $$self{colno};
-    $startLine = $$self{lineno};
+    $$self{lastlineno} = $$self{lineno};
+    $$self{lastcolno} = $$self{colno};
     if ($$self{colno} >= $$self{nchars}) {
       $$self{lineno}++;
       $$self{colno} = 0;
@@ -326,7 +328,10 @@ sub readToken {
       my $tokenString = $token->toString();
       # Switch this to 'source' for the full path.
       my $sourceName = $$self{shortsource} ? $$self{shortsource} : "unknown";
-      print "Argument token: \"$tokenString\" (source file $sourceName, from line $startLine col $startCol to line $$self{lineno} col $$self{colno})\n";
+      print "Argument token: \"$tokenString\" "
+        . "(source file $sourceName, "
+        . "from line $$self{lastlineno} col $$self{lastcolno} "
+        . "to line $$self{lineno} col $$self{colno}).\n";
     }
     return $token if defined $token;    # Else, repeat till we get something or run out.
 

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -324,15 +324,6 @@ sub readToken {
     my $token = (defined $cc ? $DISPATCH[$cc] : undef);
     $token = &$token($self, $ch) if ref $token eq 'CODE';
 
-    if ($STATE->lookupValue("IN_MATH") && $STATE->lookupValue("EXPANSION_DEPTH") && defined $token) {
-      my $tokenString = $token->toString();
-      # Switch this to 'source' for the full path.
-      my $sourceName = $$self{shortsource} ? $$self{shortsource} : "unknown";
-      print "Argument token: \"$tokenString\" "
-        . "(source file $sourceName, "
-        . "from line $$self{lastlineno} col $$self{lastcolno} "
-        . "to line $$self{lineno} col $$self{colno}).\n";
-    }
     return $token if defined $token;    # Else, repeat till we get something or run out.
 
   }

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -270,8 +270,12 @@ my @DISPATCH = (    # [CONSTANT]
 # LaTeXML::Core::Gullet intercepts them and passes them on at appropriate times.
 sub readToken {
   my ($self) = @_;
+  my $startLine;
+  my $startCol;
   while (1) {    # Iterate till we find a token, or run out. (use return)
                  # ===== Get next line, if we need to.
+    $startCol = $$self{colno};
+    $startLine = $$self{lineno};
     if ($$self{colno} >= $$self{nchars}) {
       $$self{lineno}++;
       $$self{colno} = 0;
@@ -317,6 +321,13 @@ sub readToken {
     my ($ch, $cc) = getNextChar($self);
     my $token = (defined $cc ? $DISPATCH[$cc] : undef);
     $token = &$token($self, $ch) if ref $token eq 'CODE';
+
+    if (defined $token) {
+      my $tokenString = $token->toString();
+      # Switch this to 'source' for the full path.
+      my $sourceName = $$self{shortsource} ? $$self{shortsource} : "unknown";
+      print "Token: \"$tokenString\" (source file $sourceName, from line $startLine col $startCol to line $$self{lineno} col $$self{colno})\n";
+    }
     return $token if defined $token;    # Else, repeat till we get something or run out.
 
   }

--- a/lib/LaTeXML/Core/Mouth.pm
+++ b/lib/LaTeXML/Core/Mouth.pm
@@ -322,7 +322,7 @@ sub readToken {
     my $token = (defined $cc ? $DISPATCH[$cc] : undef);
     $token = &$token($self, $ch) if ref $token eq 'CODE';
 
-    if ($STATE->lookupValue("EXPANSION_DEPTH") && defined $token) {
+    if ($STATE->lookupValue("IN_MATH") && $STATE->lookupValue("EXPANSION_DEPTH") && defined $token) {
       my $tokenString = $token->toString();
       # Switch this to 'source' for the full path.
       my $sourceName = $$self{shortsource} ? $$self{shortsource} : "unknown";

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -128,6 +128,9 @@ sub new {
 
 sub assign_internal {
   my ($self, $table, $key, $value, $scope) = @_;
+  if ($key ne "EXPANSION_DEPTH") {
+    print "Control sequence defined: $key\n";
+  }
   $scope = ($$self{prefixes}{global} ? 'global' : 'local') unless defined $scope;
   if (exists $$self{tracing_definitions}{$key}) {
     print STDERR "ASSIGN $key in $table " . ($scope ? "($scope)" : '') . " => " .

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -15,6 +15,7 @@ use warnings;
 use LaTeXML::Global;
 use LaTeXML::Common::Error;
 use LaTeXML::Core::Token;    # To get CatCodes
+use Devel::StackTrace;
 
 # Naming scheme for keys (such as it is)
 #    binding:<cs>  : the definition associated with <cs>
@@ -149,14 +150,14 @@ sub assign_internal {
     if ($$self{undo}[0]{$table}{$key}) {      # If the value was previously assigned in this frame
       $$self{$table}{$key}[0] = $value; }     # Simply replace the value
     else {                                    # Otherwise, push new value & set 1 to be undone
-      if ($key ne "EXPANSION_DEPTH") {
-        my $source = $self->getStomach->getGullet->getSource;
-        if (defined $source && !($source =~ /ltxml$/)) {
-          print "Control sequence '$key' defined when reading file $source.\n";
-        }
-      }
       $$self{undo}[0]{$table}{$key} = 1;
       unshift(@{ $$self{$table}{$key} }, $value); } }    # And push new binding.
+    if ($key ne "EXPANSION_DEPTH") {
+      my $source = $self->getStomach->getGullet->getSource;
+      if (defined $source && !($source =~ /ltxml$/)) {
+        print "Control sequence '$key' defined when reading file $source.\n";
+      }
+    }
   else {
     # print STDERR "Assigning $key in stash $stash\n";
     assign_internal($self, 'stash', $scope, [], 'global') unless $$self{stash}{$scope}[0];

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -154,7 +154,17 @@ sub assign_internal {
       unshift(@{ $$self{$table}{$key} }, $value); } }    # And push new binding.
     if ($key ne "EXPANSION_DEPTH") {
       my $source = $self->getStomach->getGullet->getSource;
-      if (defined $source && !($source =~ /ltxml$/)) {
+      if (
+        # Only report macros that have been defined outside of the 'ltxml' files (which define
+        # the macros for common TeXLive macros).
+        defined $source &&
+        !($source =~ /ltxml$/) &&
+        # Do not report macros that are defined through process of expanding other macros. This
+        # may seem obscure and coarse, though it rules out logging of internal helper macros
+        # defined in the 'siunitx' package and reporting their source as one of the main project
+        # files, rather than the ltxml file for the package.
+        !($self->lookupValue('EXPANSION_DEPTH'))
+      ) {
         print "Control sequence '$key' defined when reading file $source.\n";
       }
     }

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -128,9 +128,6 @@ sub new {
 
 sub assign_internal {
   my ($self, $table, $key, $value, $scope) = @_;
-  if ($key ne "EXPANSION_DEPTH") {
-    print "Control sequence defined: $key\n";
-  }
   $scope = ($$self{prefixes}{global} ? 'global' : 'local') unless defined $scope;
   if (exists $$self{tracing_definitions}{$key}) {
     print STDERR "ASSIGN $key in $table " . ($scope ? "($scope)" : '') . " => " .
@@ -152,6 +149,12 @@ sub assign_internal {
     if ($$self{undo}[0]{$table}{$key}) {      # If the value was previously assigned in this frame
       $$self{$table}{$key}[0] = $value; }     # Simply replace the value
     else {                                    # Otherwise, push new value & set 1 to be undone
+      if ($key ne "EXPANSION_DEPTH") {
+        my $source = $self->getStomach->getGullet->getSource;
+        if (defined $source && !($source =~ /ltxml$/)) {
+          print "Control sequence '$key' defined when reading file $source.\n";
+        }
+      }
       $$self{undo}[0]{$table}{$key} = 1;
       unshift(@{ $$self{$table}{$key} }, $value); } }    # And push new binding.
   else {

--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -164,9 +164,7 @@ sub assign_internal {
       ) {
         my $skip = 0;
         my $trace = Devel::StackTrace->new;
-        print "Before\n";
         while (my $frame = $trace->next_frame) {
-          print $frame->subroutine . "\n";
           if (
             # LaTeXML defines many internal macros while it digests tokens, in cases like:
             # 1. Beginning a new group (e.g., '{ ... }').
@@ -188,7 +186,17 @@ sub assign_internal {
             # other cases should be considered as setting a control sequence.
             ($frame->subroutine =~ /assignCatcode$/) ||
             ($frame->subroutine =~ /assignMathcode$/) ||
-            ($frame->subroutine =~ /assignValue$/)
+            ($frame->subroutine =~ /assignValue$/) ||
+            # Ignore ignore the definition of environments, counters, and registers.
+            ($frame->subroutine =~ /DefEnvironment$/) ||
+            ($frame->subroutine =~ /DefRegister$/) ||
+            ($frame->subroutine =~ /NewCounter$/) ||
+            ($frame->subroutine =~ /StepCounter$/) ||
+            ($frame->subroutine =~ /RefStepCounter$/) ||
+            # Ignore definitions created by other definition management macros.
+            ($frame->subroutine =~ /defineNewTheorem$/) ||
+            # Ignore definitions of helpers in handling key-values.
+            ($frame->subroutine =~ /KeyVals::beDigested$/)
           ) {
             $skip = 1;
             last;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,3 +3,6 @@
 *.log
 *.pdf
 texput.log
+.*.sw*
+
+.hidden

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,5 @@
+*.aux
+*.out
+*.log
+*.pdf
+texput.log

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -8,6 +8,8 @@
 \def\defcontainingstylecontrolsequence{\mathbf x}
 \newcommand{\commandwithargs}[1]{#1}
 \DeclareMathOperator{\op}{op}
+\def\nesteddefwitharg#1{\mathbf #1}
+\def\parentdef{\nesteddefwitharg{x}}
 
 \begin{document}
 
@@ -30,11 +32,15 @@ $\defcontainingstylecontrolsequence$
 
 $\defwithargs{x}{y}$
 
+$\defwithargs {x}{y}$
+
 % This is a tricky case to handle. Need to support iterative expansion.
 $\defwithargs{\simpledef}{y}$
 
 $\commandwithargs{x}$
 
 $\op x$
+
+$\parentdef$
 
 \end{document}

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -1,6 +1,7 @@
 \documentclass{article}
 
 \usepackage{amsmath}  % For \DeclareMathOperator
+\usepackage{siunitx}
 
 \def\simpledef{x}
 \def\defcontainingcontrolsequence{\simpledef + y}
@@ -10,11 +11,15 @@
 \DeclareMathOperator{\op}{op}
 \def\nesteddefwitharg#1{\mathbf #1}
 \def\parentdef{\nesteddefwitharg{xx}}
+\newcommand{\renewed}{x}
+\renewcommand{\renewed}{x}
 
 \begin{document}
 
 % For expected behavior of TeX when reading spaces, see Chapter 7 of the TeXBook
 % Can use '\relax' as a noop.
+
+$\num{10000}$
 
 % There should be no log output for this control sequence, as it appears outside 
 % of a math environment.

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -27,6 +27,11 @@ $\dots$
 % of a math environment.
 \simpledef
 
+% The log should not show that the control sequence '\\' was defined during
+% the initialization of the 'align*' environment.
+\begin{align*}
+\end{align*}
+
 % Simple case:
 % When you see a def, look at the token for it.
 % Grab the token and all of its arguments. See what gets queued into the gullet

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -1,0 +1,40 @@
+\documentclass{article}
+
+\usepackage{amsmath}  % For \DeclareMathOperator
+
+\def\simpledef{x}
+\def\defcontainingcontrolsequence{\simpledef + y}
+\def\defwithargs#1#2{#1 + #2}
+\def\defcontainingstylecontrolsequence{\mathbf x}
+\newcommand{\commandwithargs}[1]{#1}
+\DeclareMathOperator{\op}{op}
+
+\begin{document}
+
+% For expected behavior of TeX when reading spaces, see Chapter 7 of the TeXBook
+% Can use '\relax' as a noop.
+
+% There should be no log output for this control sequence, as it appears outside 
+% of a math environment.
+\simpledef
+
+% Simple case:
+% When you see a def, look at the token for it.
+% Grab the token and all of its arguments. See what gets queued into the gullet
+% during the expansion. That is the expansion.
+$\simpledef$
+
+$\defcontainingcontrolsequence$
+
+$\defcontainingstylecontrolsequence$
+
+$\defwithargs{x}{y}$
+
+% This is a tricky case to handle. Need to support iterative expansion.
+$\defwithargs{\simpledef}{y}$
+
+$\commandwithargs{x}$
+
+$\op x$
+
+\end{document}

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -9,7 +9,7 @@
 \newcommand{\commandwithargs}[1]{#1}
 \DeclareMathOperator{\op}{op}
 \def\nesteddefwitharg#1{\mathbf #1}
-\def\parentdef{\nesteddefwitharg{x}}
+\def\parentdef{\nesteddefwitharg{xx}}
 
 \begin{document}
 

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -21,6 +21,8 @@
 
 $\num{10000}$
 
+$\dots$
+
 % There should be no log output for this control sequence, as it appears outside 
 % of a math environment.
 \simpledef

--- a/test/simple-example/main.tex
+++ b/test/simple-example/main.tex
@@ -1,0 +1,8 @@
+\documentclass{article}
+
+\def\hi{\longerhi}
+\def\longerhi{Hello}
+
+\begin{document}
+\longerhi, world!
+\end{document}

--- a/test/simple-example/main.tex
+++ b/test/simple-example/main.tex
@@ -1,8 +1,0 @@
-\documentclass{article}
-
-\def\hi{\longerhi}
-\def\longerhi{Hello}
-
-\begin{document}
-\longerhi, world!
-\end{document}


### PR DESCRIPTION
This repository contains a fork of LaTeXML that I am attempting to use to automatically expand macros in LaTeX files. When an equation is written with macros in LaTeX, it becomes impossible to determine the locations of the symbols in it with our equation parser, because it is not possible to determine where the coloring commands should get inserted (becuase it is not always possible to tell if a macro in an equation stands for a symbol, and also because a macro can stand for multiple symbols each of which should be detected independently).

Hence, I am attempting to write code that will expand the macros that appear in LaTeX equations before our pipeline processes them.

TeX has an intricate grammar for parsing macros that is time-consuming to replicate. Macro expansion can also be tricky because the arguments to macros can be other macros.

To reduce the amount of work that we have to do to expand macros, I am planning to instrument LaTeXML to use it to expand macros for us. LaTeXML is a LaTeX engine that reads `.tex` documents and turns them into HTML. It is used to support the conversion of arXiv papers to web pages on the [arxiv-vanity site](https://www.arxiv-vanity.com/) and hence I hope is robust enough to process most arXiv papers that users will try to open.

Signals have been added to LaTeXML to report:

1. When a control sequence (i.e., macro) has been read that will be expanded
2. All tokens that are read as arguments for that control sequence
3. All tokens that the control sequence expands into

LaTeXML has been extended to output the character positions of all the relevant tokens from the expansion, to make it possible for our pipeline to read the logs of LaTeXML to find what tokens need to be expanded into what other tokens.

As noted above, sometimes a control sequence will expand into a form that contains _more_ control sequences. Because of this, some control sequences will need to be expanded recursively.

The comments below were written as I undertook the process of instrumenting LaTeXML. They are left in for future reference, though are not necessary to read as part of code review.