### PR TITLE
Fix LaTeXML unit tests; hide macro expansion log statements by default

### DIFF
--- a/lib/LaTeXML/Core/State.pm
+++ b/lib/LaTeXML/Core/State.pm
@@ -156,8 +156,8 @@ sub assign_internal {
       $$self{$table}{$key}[0] = $value; }     # Simply replace the value
     else {                                    # Otherwise, push new value & set 1 to be undone
       $$self{undo}[0]{$table}{$key} = 1;
-      unshift(@{ $$self{$table}{$key} }, $value); } }    # And push new binding.
-    if (0 && $self->{log_expansions} && ($key ne "EXPANSION_DEPTH")) {
+      unshift(@{ $$self{$table}{$key} }, $value); }      # And push new binding.
+    if ($self->{log_expansions} && ($key ne "EXPANSION_DEPTH")) {
       my $source = "'unknown'";
       if (
         (defined $self->getStomach) &&
@@ -215,9 +215,7 @@ sub assign_internal {
         }
         if (!$skip) {
           print "Control sequence '$key' defined when reading file $source.\n";
-        }
-      }
-    }
+        } } } }
   else {
     # print STDERR "Assigning $key in stash $stash\n";
     assign_internal($self, 'stash', $scope, [], 'global') unless $$self{stash}{$scope}[0];

--- a/test/example/main.tex
+++ b/test/example/main.tex
@@ -32,6 +32,19 @@ $\dots$
 \begin{align*}
 \end{align*}
 
+\def\nx{{\textnormal{x}}}
+
+% In buggy instrumentation, \nx will not get reported with its character 
+% positions when it is an argument to something else. Maybe need to
+% make a placeholder for root-level macros that take others as arguments.
+$\frac{1}{\nx}$
+
+% In buggy instrumentation, \nx will not be reported as occurring in a math 
+% environment when it appears very first in an align environment ¯\_(ツ)_/¯.
+\begin{align*}
+\nx
+\end{align*}
+
 % Simple case:
 % When you see a def, look at the token for it.
 % Grab the token and all of its arguments. See what gets queued into the gullet


### PR DESCRIPTION
This PR introduces a couple of small changes to clean up the recent modifications made to LaTeXML.

1. By default, LaTeXML will not show logging messages related to expanding macros _unless_ the environment variable `LATEXML_LOG_EXPANSIONS` has been set to `true`.

2. A bug was fixed in the LaTeXML that was introduced in one of my recent changes, where I entered an extra curly brace and accidentally changed the way that conditional logic was handled (see the last change in `State.pm`.